### PR TITLE
Allow empty records

### DIFF
--- a/src/Elm/Docs/Type.elm
+++ b/src/Elm/Docs/Type.elm
@@ -246,8 +246,11 @@ spaces =
 
 commaSep : Parser a -> Parser (List a)
 commaSep parser =
-  parser
-    |> Parser.andThen (\first -> commaSepHelp parser [first])
+  Parser.oneOf
+    [ parser
+        |> Parser.andThen (\first -> commaSepHelp parser [first])
+    , Parser.succeed []
+    ]
 
 
 commaSepHelp : Parser a -> List a -> Parser (List a)


### PR DESCRIPTION
Fixes the following scenario brought up in Slack:

```
> Json.Decode.decodeString Elm.Documentation.Type.decoder "\"{}\""
Err "I ran into a `fail` decoder: TODO"
    : Result.Result String Elm.Documentation.Type.Type
```

My ability to test this is rather limited without the new compiler binaries. I made the same changes in elm-tools/documentation, and it seems to fix the issue without regression.