### PR TITLE
Add an example to Elm.Type.Type for Record

### DIFF
--- a/src/Elm/Type.elm
+++ b/src/Elm/Type.elm
@@ -35,6 +35,8 @@ import String
     Maybe a        ==> Type "Maybe" [ Var "a" ]
 
     { x : Float }  ==> Record [("x", Type "Float" [])] Nothing
+
+    { v | x : Float }  ==> Record [("x", Type "Float" [])] (Just "v")
 -}
 type Type
   = Var String


### PR DESCRIPTION
It was not very clear (to me at least) what the `Maybe String` in `Record (List (String, 
Type)) (Maybe String)` was. This new example should make this more explicit.