### PR TITLE
Fix error in documentation for Elm.Docs.Union

### DIFF
--- a/src/Elm/Docs.elm
+++ b/src/Elm/Docs.elm
@@ -84,7 +84,7 @@ When it became a `Union` it would be like this:
     { name = "Maybe"
     , comment = " maybe "
     , args = ["a"]
-    , tipe =
+    , tags =
         [ ("Nothing", [])
         , ("Just", [Var "a"])
         ]


### PR DESCRIPTION
The field's name is `tags`, not `tipe`.