### PR TITLE
Accept "_" in module names

### DIFF
--- a/src/Elm/Module.elm
+++ b/src/Elm/Module.elm
@@ -70,7 +70,12 @@ isGoodChunk chunk =
       False
 
     Just (char, rest) ->
-      Char.isUpper char && String.all Char.isAlphaNum rest
+      Char.isUpper char && String.all isValidModuleNameCharacter rest
+
+
+isValidModuleNameCharacter : Char -> Bool
+isValidModuleNameCharacter char =
+  Char.isAlphaNum char || char == '_'
 
 
 


### PR DESCRIPTION
Tackles #12, and allows `_` in module names.

This does not add the missing support for unicode characters, with which I am too unfamiliar.