### PR TITLE
Have Elm.Project.encode order the dependencies the same way the compiler does

### DIFF
--- a/src/Elm/Project.elm
+++ b/src/Elm/Project.elm
@@ -144,7 +144,7 @@ encodeChunk (header, list) =
 
 encodeDeps : (constraint -> E.Value) -> Deps constraint -> E.Value
 encodeDeps encodeConstraint deps =
-  E.object <| List.sortBy Tuple.first <|
+  E.object <| List.sortBy (String.split "/" << Tuple.first) <|
     List.map (encodeDep encodeConstraint) deps
 
 


### PR DESCRIPTION
The Elm.Project.encode function previously did an alphabetical sort, which means that packages like "elm-community/*" would show up before "elm/*". The compiler, elm-json and elm-test-rs all on the other hand seem to sort by author then by package name, so "elm/*" shows up before "elm-community/*".

This change makes it so that the author name is compared first, then the package name, to act like the compiler and the other tools.

I noticed this because `elm-review` now allows for automatic fixes for `elm.json` files where we use `Elm.Project.encode` to write the contents of the file. Doing so would change the order of the dependencies in a way that creates confusion to the user ("oh why did it remove this dependency? Oh it just moved it alright")